### PR TITLE
Bump studio and add version info to constructor

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@prisma/fetch-engine": "workspace:0.3.34",
     "@prisma/get-platform": "workspace:0.1.23",
     "@prisma/ink-components": "workspace:0.0.22",
-    "@prisma/studio-server": "0.191.0",
+    "@prisma/studio-server": "0.193.0",
     "@types/execa": "2.0.0",
     "ansi-escapes": "4.2.1",
     "cli-cursor": "3.1.0",

--- a/src/Studio.ts
+++ b/src/Studio.ts
@@ -68,13 +68,17 @@ export class Studio {
         binaryPaths: {
           queryEngine: firstExistingPath.path,
         },
-        photon: {
+        prismaClient: {
           generator: {
             version: packageJson.prisma.version,
             providerAliases,
           },
         },
         staticAssetDir: path.resolve(__dirname, 'public'), // Overriding this directory since after NCC compilation, this won't resolve automatically
+        versions: {
+          prisma2: packageJson.version,
+          queryEngine: packageJson.prisma.version,
+        },
       })
 
       await this.instance.start()


### PR DESCRIPTION
Also account for rename of photon to prismaClient

Please merge after any preview releases today.

@timsuchanek AFAIK, this version bump would not be sufficient to also bump studio-server's version in prisma2. Once this is merged, I'll start a new build over at our CI.