### PR TITLE
Renaming migration-engine with platform name for prisma/prisma2#1049

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-migration-engine
 migration-engine*
 yarn-error.log
 dist

--- a/src/liftEngineCommands.ts
+++ b/src/liftEngineCommands.ts
@@ -13,7 +13,7 @@ async function getMigrationEnginePath(): Promise<string> {
   const dir = eval('__dirname')
   const platform = await getPlatform()
   const extension = platform === 'windows' ? '.exe' : ''
-  const relative = `../migration-engine${extension}`
+  const relative = `../migration-engine-${platform}${extension}`
   return path.join(dir, relative)
 }
 


### PR DESCRIPTION
For prisma/prisma2#1049

Related changes
https://github.com/prisma/prisma2/commit/29c46da209f149162e35e9c0abb33e70823c6757
https://github.com/prisma/prisma-client-js/commit/97ab5732ec18ef94163195aae4e3fa227a6324af