### PR TITLE
chore(issue/tpl/bug): comment version examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -39,7 +39,7 @@ Do not include your database credentials when sharing your Prisma schema! -->
 
 <!-- In which environment does the problem occur -->
 
-- OS: [e.g. Mac OS, Windows, Debian, CentOS, ...]
-- Database: [PostgreSQL, MySQL, MariaDB or SQLite]
-- Prisma version: [Run `prisma -v` to see your Prisma version]
-- Node.js version: [Run `node -v` to see your Node.js version]
+- OS: <!--[e.g. Mac OS, Windows, Debian, CentOS, ...]-->
+- Database: <!--[PostgreSQL, MySQL, MariaDB or SQLite]-->
+- Prisma version: <!--[Run `prisma -v` to see your Prisma version]-->
+- Node.js version: <!--[Run `node -v` to see your Node.js version]-->


### PR DESCRIPTION
A suggestion to comment out version examples so they don't end up in the final issue. What do you think? cc @nikolasburk 

The only thing which can go wrong here is that users may comment out existing examples and the remaining one stays in the comment.. not sure.